### PR TITLE
Make building the stubs configurable using an env var

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ coverage = [ "uuid" ]
 
 [build-dependencies]
 bindgen = "0.52.0"
+cmake = "0.1"
 
 [dependencies]
 log = "^0.4"

--- a/stubs/CMakeLists.txt
+++ b/stubs/CMakeLists.txt
@@ -7,18 +7,16 @@ project(greengrasssdkstub)
 ############################################################
 
 #Generate the shared library from the library sources
-add_library(greengrasssdk SHARED 
+add_library(greengrasssdk SHARED
     src/greengrasssdk.c
 )
 add_library(greengrasssdk::library ALIAS greengrasssdk)
 
 set_target_properties(greengrasssdk PROPERTIES OUTPUT_NAME "aws-greengrass-core-sdk-c")
 target_include_directories(greengrasssdk
-    PUBLIC 
+    PUBLIC
         ${PROJECT_SOURCE_DIR}/include
 )
 
 install(TARGETS greengrasssdk DESTINATION lib)
 install(FILES include/shared/greengrasssdk.h DESTINATION include)
-
-


### PR DESCRIPTION
This not only makes it a bit easier to locally compile on non-Linux systems, but it also makes cross-compiling quite easy.

Given that you have created a cmake toolchain file for Linux, running something like this (in the project that depends on this crate) will cross-compile you code:

```sh
$ AWS_GREENGRASS_STUBS=yes CMAKE_TOOLCHAIN_FILE=$(pwd)/linux-gnu-x86_64.cmake cargo build --target=x86_64-unknown-linux-gnu
```

FYI I did notice the request to sign an Individual Contributor License Agreement and to read the Code of Conduct, but both links currently return 404's. I'm fine with signing something if that's needed. I'm also fine if you copy and paste these changes in a PR of your own if that makes things easier 👍 